### PR TITLE
Improved documentation for `value`

### DIFF
--- a/src/Html/Attributes.gren
+++ b/src/Html/Attributes.gren
@@ -434,7 +434,7 @@ type_ =
   stringProperty "type"
 
 
-{-| Defines a default value which will be displayed in a `button`, `option`,
+{-| The value which will be displayed in a `button`, `option`,
 `input`, `li`, `meter`, `progress`, or `param`.
 -}
 value : String -> Attribute msg


### PR DESCRIPTION
The old description to me implied a default value set up during initial load of the DOM, not the current value. If you do `input [value "1"] []` any input you make in the input will be overwritten at the next update loop.